### PR TITLE
w_tilde_*_from jitted by JAX

### DIFF
--- a/w_tilde/w_tilde_curvature.py
+++ b/w_tilde/w_tilde_curvature.py
@@ -28,6 +28,9 @@ def w_tilde_curvature_interferometer_from(
     `w_tilde_preload_interferometer_from` describes a compressed representation that overcomes this hurdles. It is
     advised `w_tilde` and this method are only used for testing.
 
+    Note that the current implementation does not take advantage of the fact that w_tilde is symmetric,
+    due to the use of vectorized operations.
+
     .. math::
         W̃_{ij} = \sum_{k=1}^N \frac{1}{n_k^2} \cos(2\pi[(g_{i1} - g_{j1})u_{k0} + (g_{i0} - g_{j0})u_{k1}])
 

--- a/w_tilde/w_tilde_curvature.py
+++ b/w_tilde/w_tilde_curvature.py
@@ -41,18 +41,18 @@ def w_tilde_curvature_interferometer_from(
 
     Parameters
     ----------
-    noise_map_real : ndarray, shape (N,), dtype=float64
+    noise_map_real
         The real noise-map values of the interferometer data.
-    uv_wavelengths : ndarray, shape (N, 2), dtype=float64
+    uv_wavelengths
         The wavelengths of the coordinates in the uv-plane for the interferometer dataset that is to be Fourier
         transformed.
-    grid_radians_slim : ndarray, shape (M, 2), dtype=float64
+    grid_radians_slim
         The 1D (y,x) grid of coordinates in radians corresponding to real-space mask within which the image that is
         Fourier transformed is computed.
 
     Returns
     -------
-    ndarray : ndarray, shape (M, M), dtype=float64
+    ndarray
         A matrix that encodes the NUFFT values between the noise map that enables efficient calculation of the curvature
         matrix.
     """

--- a/w_tilde/w_tilde_curvature.py
+++ b/w_tilde/w_tilde_curvature.py
@@ -48,22 +48,18 @@ def w_tilde_curvature_interferometer_from(
         A matrix that encodes the NUFFT values between the noise map that enables efficient calculation of the curvature
         matrix.
     """
+    # (i∊M, j∊M, 1, 2)
+    g_ij =  grid_radians_slim.reshape(-1, 1, 1, 2) - grid_radians_slim.reshape(1, -1, 1, 2)
+    # (1, 1, k∊N, 2)
+    u_k = uv_wavelengths.reshape(1, 1, -1, 2)
     return (
         jnp.cos(
             (2.0 * jnp.pi) *
             # (M, M, N)
             (
-                (
-                    # (i∊M, 1, 1, 2)
-                    grid_radians_slim.reshape(-1, 1, 1, 2) -
-                    # (1, j∊M, 1, 2)
-                    grid_radians_slim.reshape(1, -1, 1, 2)
-                ) * np.flip(
-                    # (1, 1, k∊N, 2)
-                    uv_wavelengths.reshape(1, 1, -1, 2),
-                    3,
-                )
-            ).sum(3)
+                g_ij[:, :, :, 0] * u_k[:, :, :, 1] +
+                g_ij[:, :, :, 1] * u_k[:, :, :, 0]
+            )
         ) /
         # (1, 1, k∊N)
         jnp.square(noise_map_real).reshape(1, 1, -1)

--- a/w_tilde/w_tilde_curvature.py
+++ b/w_tilde/w_tilde_curvature.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from os import path
 
@@ -10,13 +12,16 @@ from autoarray import numba_util
 
 import autolens as al
 
+if TYPE_CHECKING:
+    from typing import Tuple
+
 
 @jit
 def w_tilde_curvature_interferometer_from(
-    noise_map_real: np.ndarray[tuple[int], np.float64],
-    uv_wavelengths: np.ndarray[tuple[int, int], np.float64],
-    grid_radians_slim: np.ndarray[tuple[int, int], np.float64],
-) -> np.ndarray[tuple[int, int], np.float64]:
+    noise_map_real: np.ndarray[Tuple[int], np.float64],
+    uv_wavelengths: np.ndarray[Tuple[int, int], np.float64],
+    grid_radians_slim: np.ndarray[Tuple[int, int], np.float64],
+) -> np.ndarray[Tuple[int, int], np.float64]:
     """
     The matrix w_tilde is a matrix of dimensions [image_pixels, image_pixels] that encodes the NUFFT of every pair of
     image pixels given the noise map. This can be used to efficiently compute the curvature matrix via the mappings

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -59,19 +59,19 @@ def w_tilde_data_interferometer_from(
         efficient calculation of the data vector.
     """
     return (
-        # (1, N)
+        # (1, j∊N)
         jnp.square(jnp.square(noise_map_real) / visibilities_real).reshape(1, -1) *
         jnp.cos(
             (2.0 * jnp.pi) *
-            # (M, N)
+            # (i∊M, j∊N)
             (
-                # (M, 1, 2)
+                # (i∊M, 1, 2)
                 jnp.flip(grid_radians_slim.reshape(-1, 1, 2), 2) *
-                # (1, N, 2)
+                # (1, j∊N, 2)
                 uv_wavelengths.reshape(1, -1, 2)
             ).sum(axis=2)
         )
-    ).sum(axis=1)
+    ).sum(axis=1)  # sum over j
 
 
 

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -58,6 +58,8 @@ def w_tilde_data_interferometer_from(
         A matrix that encodes the PSF convolution values between the imaging divided by the noise map**2 that enables
         efficient calculation of the data vector.
     """
+    g_i = grid_radians_slim.reshape(-1, 1, 2)
+    u_j = uv_wavelengths.reshape(1, -1, 2)
     return (
         # (1, j∊N)
         jnp.square(jnp.square(noise_map_real) / visibilities_real).reshape(1, -1) *
@@ -65,14 +67,11 @@ def w_tilde_data_interferometer_from(
             (2.0 * jnp.pi) *
             # (i∊M, j∊N)
             (
-                # (i∊M, 1, 2)
-                jnp.flip(grid_radians_slim.reshape(-1, 1, 2), 2) *
-                # (1, j∊N, 2)
-                uv_wavelengths.reshape(1, -1, 2)
-            ).sum(axis=2)
+                g_i[:, :, 0] * u_j[:, :, 1] +
+                g_i[:, :, 1] * u_j[:, :, 0]
+            )
         )
     ).sum(axis=1)  # sum over j
-
 
 
 """

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 from os import path
 
@@ -10,15 +12,18 @@ from autoarray import numba_util
 
 import autolens as al
 
+if TYPE_CHECKING:
+    from typing import Tuple
+
 
 @jit
 def w_tilde_data_interferometer_from(
-    visibilities_real: np.ndarray[tuple[int], np.float64],
-    noise_map_real: np.ndarray[tuple[int], np.float64],
-    uv_wavelengths: np.ndarray[tuple[int, int], np.float64],
-    grid_radians_slim: np.ndarray[tuple[int, int], np.float64],
-    native_index_for_slim_index: np.ndarray[tuple[int, int], np.int64],
-) -> np.ndarray[tuple[int], np.float64]:
+    visibilities_real: np.ndarray[Tuple[int], np.float64],
+    noise_map_real: np.ndarray[Tuple[int], np.float64],
+    uv_wavelengths: np.ndarray[Tuple[int, int], np.float64],
+    grid_radians_slim: np.ndarray[Tuple[int, int], np.float64],
+    native_index_for_slim_index: np.ndarray[Tuple[int, int], np.int64],
+) -> np.ndarray[Tuple[int], np.float64]:
     """
     The matrix w_tilde is a matrix of dimensions [image_pixels, image_pixels] that encodes the PSF convolution of
     every pair of image pixels given the noise map. This can be used to efficiently compute the curvature matrix via

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -38,6 +38,9 @@ def w_tilde_data_interferometer_from(
         @jit("float64[::1](float64[::1], float64[::1], float64[:,::1], float64[:,::1], int64[:,::1])", nopython=True, nogil=True, parallel=True)
     but numba doesn't like the combination of flip and reshape there.
 
+    .. math::
+        \tilde{w}_{\text{data},i} = \sum_{j=1}^N \left(\frac{N_{r,j}^2}{V_{r,j}}\right)^2 \cos\left(2\pi(g_{i,1}u_{j,0} + g_{i,0}u_{j,1})\right)
+
     Parameters
     ----------
     visibilities_real : ndarray, shape (N,), dtype=float64

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -34,10 +34,6 @@ def w_tilde_data_interferometer_from(
 
     weight = image / noise**2.0
 
-    This function can almost be numba-jitted with
-        @jit("float64[::1](float64[::1], float64[::1], float64[:,::1], float64[:,::1], int64[:,::1])", nopython=True, nogil=True, parallel=True)
-    but numba doesn't like the combination of flip and reshape there.
-
     .. math::
         \tilde{w}_{\text{data},i} = \sum_{j=1}^N \left(\frac{N_{r,j}^2}{V_{r,j}}\right)^2 \cos\left(2\pi(g_{i,1}u_{j,0} + g_{i,0}u_{j,1})\right)
 

--- a/w_tilde/w_tilde_data.py
+++ b/w_tilde/w_tilde_data.py
@@ -44,18 +44,17 @@ def w_tilde_data_interferometer_from(
 
     Parameters
     ----------
-    visibilities_real : ndarray, shape (N,), dtype=float64
+    visibilities_real
         The two dimensional masked image of values which `w_tilde_data` is computed from.
-    noise_map_real : ndarray, shape (N,), dtype=float64
+    noise_map_real
         The two dimensional masked noise-map of values which `w_tilde_data` is computed from.
-    uv_wavelengths : ndarray, shape (N, 2), dtype=float64
-    grid_radians_slim : ndarray, shape (M, 2), dtype=float64
-    native_index_for_slim_index : ndarray, shape (M, 2), dtype=int64
+    uv_wavelengths
+    grid_radians_slim
+    native_index_for_slim_index
         An array that maps pixels from the slimmed array to the native array.
 
     Returns
     -------
-    ndarray, shape (M,), dtype=float64
         A matrix that encodes the PSF convolution values between the imaging divided by the noise map**2 that enables
         efficient calculation of the data vector.
     """


### PR DESCRIPTION
Discussion points:

- [x] is test needed? Before I created this PR, I basically wrote the original output to a file and check that this function is `allclose` to the original output.
- [x] Currently, `jax.jit` is used directly. Do you want me to point to `numba_util.jit` instead?
- [x] I `import jax.numpy as jnp`, as I need the namespace of `np.ndarray` for type hints. Need change here?